### PR TITLE
[fix] Replace `value` with `placeholder` in bug report template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -18,7 +18,7 @@ body:
     attributes:
       label: "Reproduction steps"
       description: Please enter an explicit description of your issue
-      value: |
+      placeholder: |
         1. Go to '...'
         2. Click on '....'
         3. Scroll down to '....'
@@ -31,7 +31,7 @@ body:
     attributes:
       label: "Screenshots"
       description: If applicable, add screenshots to help explain your problem.
-      value: |
+      placeholder: |
         ![DESCRIPTION](LINK.png)
       render: bash
     validations:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
 name: "Bug Report"
 description: Create a new ticket for a bug.
-title: "[BUG] - <title>"
+title: "[BUG] "
 labels: [
   "bug"
 ]

--- a/.github/ISSUE_TEMPLATE/cust.yml
+++ b/.github/ISSUE_TEMPLATE/cust.yml
@@ -1,6 +1,6 @@
 name: "General Issue"
 description: Create a new ticket for issues not covered by other templates.
-title: "[ISSUE] - <title>"
+title: "[ISSUE] "
 labels: [
   "question",
   "help wanted"

--- a/.github/ISSUE_TEMPLATE/feat.yml
+++ b/.github/ISSUE_TEMPLATE/feat.yml
@@ -1,6 +1,6 @@
 name: "Feature Request"
 description: Create a new ticket for a feature request.
-title: "[FEATURE] - <title>"
+title: "[FEATURE] "
 labels: [
   "enhancement"
 ]


### PR DESCRIPTION
This pull request includes changes to the GitHub issue templates to improve their usability and clarity. The most important changes include updating the titles and modifying the body placeholders for better user guidance.

Updates to issue templates:

* [`.github/ISSUE_TEMPLATE/bug.yml`](diffhunk://#diff-45b5634e925b86895feee745ec5650893bae0d56e11b379745e506fd9a6b81bdL3-R3): Removed the hyphen and angle brackets from the title and replaced the `value` fields with `placeholder` fields for reproduction steps and screenshots. [[1]](diffhunk://#diff-45b5634e925b86895feee745ec5650893bae0d56e11b379745e506fd9a6b81bdL3-R3) [[2]](diffhunk://#diff-45b5634e925b86895feee745ec5650893bae0d56e11b379745e506fd9a6b81bdL21-R21) [[3]](diffhunk://#diff-45b5634e925b86895feee745ec5650893bae0d56e11b379745e506fd9a6b81bdL34-R34)
* [`.github/ISSUE_TEMPLATE/cust.yml`](diffhunk://#diff-f0482eb01f2681eb9372fa55a9a756f3f2454f7d885dde36e89b59033edc8abeL3-R3): Removed the hyphen and angle brackets from the title.
* [`.github/ISSUE_TEMPLATE/feat.yml`](diffhunk://#diff-4fd70bb846bf944f8d15aab7c6572e28f6e53235f6cfbf2d7d4880f659065c71L3-R3): Removed the hyphen and angle brackets from the title.

The pull request addresses the issue #10 