### PR TITLE
Added new label to bug issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -3,7 +3,7 @@ description: Create a new ticket for a bug.
 title: "[BUG] "
 labels: [
   "bug",
-  "created-with-issues-template"
+  "issues-template"
 ]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -2,7 +2,8 @@ name: "Bug Report"
 description: Create a new ticket for a bug.
 title: "[BUG] "
 labels: [
-  "bug"
+  "bug",
+  "created-with-issues-template"
 ]
 body:
   - type: textarea


### PR DESCRIPTION
The new label was added to the bug issue template, in preparation for the GitHub actions workflow that will clear empty fields from issues made with issue templates.
#10 
