### PR TITLE
feat: Clean Up Bug Report Issue's Empty Fields

### DIFF
--- a/.github/workflows/clean-issues.yml
+++ b/.github/workflows/clean-issues.yml
@@ -1,0 +1,63 @@
+name: Clean New Issue Body
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  edit-issue-body:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Clean issue body
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            let newBody1 = issue.body;
+
+            if(issue.labels.some(label => label.name === "issues-template")){               
+                let newBody = issue.body.split('\n');
+                newBody1 = "";
+
+                for(let i=0; i<newBody.length; ++i){
+                    if(newBody[i].includes("### Screenshots") && i+5<newBody.length){
+                        if(newBody.slice(i, i+6).join('').replace(/\s+/g, '') === "###Screenshots```bash```"){
+                            newBody.splice(i, 6, ...Array(6).fill(""));
+                        }
+                    }
+                    if(newBody[i].includes("### Logs") && i+5<newBody.length){
+                        if(newBody.slice(i, i+6).join('').replace(/\s+/g, '') === "###Logs```bash```"){
+                            newBody.splice(i, 6, ...Array(6).fill(""));
+                        }
+                    }
+                    if(newBody[i].includes("### Browsers") && i+3<newBody.length){
+                        if(newBody.slice(i, i+4).join('').replace(/\s+/g, '') === "###Browsers_Noresponse_"){
+                            newBody.splice(i, 4, ...Array(4).fill(""));
+                        }
+                    }
+                    if(newBody[i].includes("### OS") && i+2<newBody.length){
+                        if(newBody.slice(i, i+3).join('').replace(/\s+/g, '') === "###OS_Noresponse_"){
+                            newBody.splice(i, 3, ...Array(3).fill(""));
+                        }
+                    }
+                    if(newBody[i] != ""){
+                        newBody1 += newBody[i] + '\n';
+                    }
+                }
+            }
+
+            await github.rest.issues.update({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            body: newBody1,
+            });


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to clean the body of newly opened issues. The workflow targets specific sections in the issue template and removes predefined placeholder content if it is not replaced by the user.

Key changes include:

* [`.github/workflows/clean-issues.yml`](diffhunk://#diff-6f7920947aad5c69e8d7ce6cd8ec4e9d72866e2ec5b0ddf9e3f0072d5b99c3aaR1-R63): Added a new workflow that triggers on issue creation. It uses `actions/github-script@v6` to check for specific labels and clean the issue body by removing placeholder content in sections like "Screenshots," "Logs," "Browsers," and "OS" if they are left with default text.

#10 